### PR TITLE
Bug/fix drag and drop on mac

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -110,6 +110,9 @@
                      "browserTarget": "sandbox:build:development"
                   }
                },
+               "options": {
+                  "port": 4400
+               },
                "defaultConfiguration": "development"
             },
             "extract-i18n": {

--- a/projects/limble-tree/src/lib/components/dropzone/dropzone.component.scss
+++ b/projects/limble-tree/src/lib/components/dropzone/dropzone.component.scss
@@ -1,16 +1,18 @@
+$--limble-tree-dropzone-height: 36px;
+
 .dropzone {
    border-radius: 8px;
    border: 1px dashed #727374;
    background-color: #ededed;
-   height: 20px;
+   height: $--limble-tree-dropzone-height;
    margin: 8px 0 8px 0;
-   transition: height 0.2s ease-out;
-   animation: animation 0.2s ease-out;
+   transition: height 0.3s ease-out;
+   animation: animation 0.3s ease-out;
    &.active {
       border-color: #289e49;
       border-width: 2px;
       background-color: #d0e8d6;
-      height: 48px;
+      height: calc($--limble-tree-dropzone-height * 2);
    }
 }
 
@@ -20,7 +22,7 @@
       opacity: 0;
    }
    to {
-      height: 20px;
+      height: $--limble-tree-dropzone-height;
       opacity: 1;
    }
 }

--- a/projects/limble-tree/src/lib/extras/drag-and-drop/dragover-no-change-detect.ts
+++ b/projects/limble-tree/src/lib/extras/drag-and-drop/dragover-no-change-detect.ts
@@ -2,14 +2,12 @@ import {
    Directive,
    ElementRef,
    EventEmitter,
-   Input,
    NgZone,
    type OnDestroy,
    type OnInit,
    Output
 } from "@angular/core";
 import { fromEvent, type Subscription } from "rxjs";
-import { throttleTime } from "rxjs/operators";
 
 /**
  * Works just like Angular's built-in `(dragover)` event binding, but is much
@@ -21,7 +19,6 @@ import { throttleTime } from "rxjs/operators";
    selector: "[dragoverNoChangeDetect]"
 })
 export class DragoverNoChangeDetectDirective implements OnInit, OnDestroy {
-   @Input() dragoverEventThrottle: number;
    @Output() readonly dragoverNoChangeDetect: EventEmitter<DragEvent>;
    private eventSubscription: Subscription | undefined;
 
@@ -30,7 +27,6 @@ export class DragoverNoChangeDetectDirective implements OnInit, OnDestroy {
       private readonly el: ElementRef<Element>
    ) {
       this.dragoverNoChangeDetect = new EventEmitter<DragEvent>();
-      this.dragoverEventThrottle = 25;
    }
 
    public ngOnInit(): void {

--- a/projects/limble-tree/src/lib/extras/drag-and-drop/dragover-no-change-detect.ts
+++ b/projects/limble-tree/src/lib/extras/drag-and-drop/dragover-no-change-detect.ts
@@ -38,11 +38,9 @@ export class DragoverNoChangeDetectDirective implements OnInit, OnDestroy {
          this.eventSubscription = fromEvent<DragEvent>(
             this.el.nativeElement,
             "dragover"
-         )
-            .pipe(throttleTime(this.dragoverEventThrottle))
-            .subscribe(($event) => {
-               this.dragoverNoChangeDetect.emit($event);
-            });
+         ).subscribe(($event) => {
+            this.dragoverNoChangeDetect.emit($event);
+         });
       });
    }
 

--- a/projects/sandbox/src/app/app.component.ts
+++ b/projects/sandbox/src/app/app.component.ts
@@ -119,7 +119,13 @@ export class AppComponent implements AfterViewInit {
          defaultCollapsed: true
       });
       branch1.grow(DraggableComponent);
-      branch2.grow(LoremIpsumComponent);
+      branch2
+         .grow(LoremIpsumComponent)
+         .grow(DraggableComponent)
+         .grow(DraggableComponent)
+         .grow(DraggableComponent)
+         .grow(DraggableComponent)
+         .grow(DraggableComponent);
       branch3.grow(DraggableComponent);
       branch1b.grow(LoremIpsumComponent);
       const root2 = this.treeService.createEmptyTree<


### PR DESCRIPTION
### Context
On Mac for some reason throttling the dragoverNoChangeDetect event causes the drop event to not fire.  This breaks the ability to rearrange a tree on Macs.

### Changes
Removed throttling from the DragoverNoChangeDetectDirective.
