### PR TITLE
More intuitive error handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
       "editor.defaultFormatter": "esbenp.prettier-vscode"
    },
    "intelephense.environment.phpVersion": "7.3.18",
-   "typescript.tsdk": "node_modules\\typescript\\lib",
+   "typescript.tsdk": "node_modules/typescript/lib",
    "cSpell.words": [
       "angular",
       "Angular",

--- a/projects/limble-tree/package.json
+++ b/projects/limble-tree/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@limble/limble-tree",
-   "version": "1.0.0-beta.1",
+   "version": "1.0.0-beta.2",
    "peerDependencies": {
       "@angular/common": "^14.2.0",
       "@angular/core": "^14.2.0",

--- a/projects/limble-tree/src/lib/core/tree-branch/tree-branch.spec.ts
+++ b/projects/limble-tree/src/lib/core/tree-branch/tree-branch.spec.ts
@@ -15,6 +15,9 @@ import { TreeEvent } from "../../structure";
 import { DestructionEvent } from "../../events/general";
 import { NodeComponent } from "../../components/node-component.interface";
 import { ViewContainerRef } from "@angular/core";
+import { ErrorConstructorComponent } from "../../test-util/error-constructor.component";
+import { ErrorInitComponent } from "../../test-util/error-init.component";
+import { BranchGrowthComponent } from "../../test-util/branch-growth.component";
 
 describe("TreeBranch", () => {
    it("should start with no branches", () => {
@@ -652,5 +655,71 @@ describe("TreeBranch", () => {
       expect(() => {
          self.graftTo(grandchild);
       }).toThrowError(TreeError);
+   });
+
+   it("should throw an error and destroy the tree when an error is thrown in the constructor of a child's userland component", () => {
+      const root = new TreeRoot<ErrorConstructorComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      const branch = new TreeBranch(root, {
+         component: EmptyComponent
+      });
+      expect(() => {
+         branch.grow(ErrorConstructorComponent);
+      }).toThrow();
+      expect(branch.isDestroyed()).toBe(true);
+      expect(root.isDestroyed()).toBe(true);
+   });
+
+   it("should throw an error and destroy the tree when an error is thrown in the ngOnInit hook of a child's userland component", () => {
+      const root = new TreeRoot<ErrorInitComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      const branch = new TreeBranch(root, {
+         component: EmptyComponent
+      });
+      expect(() => {
+         branch.grow(ErrorInitComponent);
+      }).toThrow();
+      expect(branch.isDestroyed()).toBe(true);
+      expect(root.isDestroyed()).toBe(true);
+   });
+
+   it("should throw an error and destroy its furthest ancestor branch when an error is thrown in the constructor of a child's userland component and the branch is part of a pruned segment", () => {
+      const root = new TreeRoot<ErrorConstructorComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      const branch = new TreeBranch(root, {
+         component: EmptyComponent
+      });
+      branch.prune();
+      expect(() => {
+         branch.grow(ErrorConstructorComponent);
+      }).toThrow();
+      expect(branch.isDestroyed()).toBe(true);
+      expect(root.isDestroyed()).toBe(false);
+   });
+
+   it("should throw an error and destroy its furthest ancestor branch when an error is thrown in the ngOnInit hook of a child's userland component and the branch is part of a pruned segment", () => {
+      const root = new TreeRoot<ErrorInitComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      const branch = new TreeBranch(root, {
+         component: EmptyComponent
+      });
+      branch.prune();
+      expect(() => {
+         branch.grow(ErrorInitComponent);
+      }).toThrow();
+      expect(branch.isDestroyed()).toBe(true);
+      expect(root.isDestroyed()).toBe(false);
+   });
+
+   it("should be able to host a userland component which grows additional branches onto itself", () => {
+      const root = new TreeRoot<BranchGrowthComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      const branch = root.grow(BranchGrowthComponent);
+      expect(branch.branches().length).toBe(2);
    });
 });

--- a/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
+++ b/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
@@ -62,16 +62,16 @@ export class TreeBranch<UserlandComponent>
          this,
          parentBranchesContainer
       );
+      const hostView = this.branchController.getHostView();
       this.setIndentation(parent);
       if (
          parent instanceof TreeBranch &&
          parent.branchOptions.defaultCollapsed === true
       ) {
          treeCollapser.storePrecollapsedNode(parent, this);
-         this.detachedView = this.branchController.getHostView();
+         this.detachedView = hostView;
       } else {
-         parentBranchesContainer.insert(this.branchController.getHostView());
-         this.detectChanges();
+         parentBranchesContainer.insert(hostView);
          this._parent = parent;
          this.dispatch(
             new GraftEvent(this, {
@@ -80,6 +80,7 @@ export class TreeBranch<UserlandComponent>
                index: this._parent.branches().length
             })
          );
+         this.detectChanges();
       }
    }
 

--- a/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
+++ b/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
@@ -265,7 +265,11 @@ export class TreeBranch<UserlandComponent>
       if (this.isDestroyed()) {
          throw new TreeError("Cannot grow a branch on a destroyed tree branch");
       }
-      return new TreeBranch(this, { component, ...options });
+      try {
+         return new TreeBranch(this, { component, ...options });
+      } catch (error: unknown) {
+         this.handleUserlandError(error);
+      }
    }
 
    /**
@@ -477,11 +481,34 @@ export class TreeBranch<UserlandComponent>
       });
    }
 
+   private handleUserlandError(error: unknown): never {
+      // When an error occurs in a userland component during a tree operation,
+      // it can cause undefined, bizarre behavior in the tree. To prevent this,
+      // we destroy the tree and throw an error instead. This helps protect
+      // the end-user's data from corruption.
+      this.furthestAncestor().destroy();
+      this.treeNodeBase.handleUserlandError(error);
+   }
+
    private indexIsOutOfRange(
       parent: TreeNode<TreeBranch<UserlandComponent>, NodeComponent>,
       index: number
    ): boolean {
       return index < 0 || index > parent.branches().length;
+   }
+
+   private furthestAncestor(): TreeNode<
+      TreeBranch<UserlandComponent>,
+      NodeComponent
+   > {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias -- This code is for an iteration, not to make `this` available in other scopes (which is what the rule is intended to protect against).
+      let node: TreeNode<TreeBranch<UserlandComponent>, NodeComponent> = this;
+      while (node instanceof TreeBranch) {
+         const parent = node.parent();
+         if (parent === undefined) break;
+         node = parent;
+      }
+      return node;
    }
 
    private reattachView(index?: number): void {

--- a/projects/limble-tree/src/lib/core/tree-node-base.ts
+++ b/projects/limble-tree/src/lib/core/tree-node-base.ts
@@ -1,4 +1,5 @@
 import { filter, Observable, Subject, Subscription } from "rxjs";
+import { hasProperty } from "../../shared/has-property";
 import { NodeComponent } from "../components/node-component.interface";
 import { TreeError } from "../errors";
 import { GraftEvent } from "../events/relational/graft-event";
@@ -54,6 +55,18 @@ export class TreeNodeBase<UserlandComponent>
 
    public getBranch(index: number): TreeBranch<UserlandComponent> | undefined {
       return this._branches[index];
+   }
+
+   public handleUserlandError(error: unknown): never {
+      const message = hasProperty(error, "message")
+         ? error.message
+         : "Unknown error";
+      throw new TreeError(`Failed to grow branch: ${message}`, {
+         // This cast to `any` is due to an issue in typescript that has been
+         // resolved at least by version 4.9.5. When we upgrade our typescript
+         // version we can remove the cast.
+         cause: error as any
+      });
    }
 
    public isDestroyed(): boolean {

--- a/projects/limble-tree/src/lib/core/tree-root/tree-root.spec.ts
+++ b/projects/limble-tree/src/lib/core/tree-root/tree-root.spec.ts
@@ -12,6 +12,8 @@ import { RootComponent } from "../../components/root/root.component";
 import { TreeError } from "../../errors";
 import { DestructionEvent } from "../../events/general";
 import { NodeComponent } from "../../components/node-component.interface";
+import { ErrorConstructorComponent } from "../../test-util/error-constructor.component";
+import { ErrorInitComponent } from "../../test-util/error-init.component";
 
 describe("TreeRoot", () => {
    it("should start with no branches", () => {
@@ -307,5 +309,25 @@ describe("TreeRoot", () => {
       const root = new TreeRoot<EmptyComponent>(getViewContainer());
       root.destroy();
       expect(() => root.getNativeElement()).toThrowError(TreeError);
+   });
+
+   it("should throw an error and destroy itself when an error is thrown in the constructor of a child's userland component", () => {
+      const root = new TreeRoot<ErrorConstructorComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      expect(() => {
+         root.grow(ErrorConstructorComponent);
+      }).toThrow();
+      expect(root.isDestroyed()).toBe(true);
+   });
+
+   it("should throw an error and destroy itself when an error is thrown in the ngOnInit hook of a child's userland component", () => {
+      const root = new TreeRoot<ErrorInitComponent | EmptyComponent>(
+         getViewContainer()
+      );
+      expect(() => {
+         root.grow(ErrorInitComponent);
+      }).toThrow();
+      expect(root.isDestroyed()).toBe(true);
    });
 });

--- a/projects/limble-tree/src/lib/core/tree-root/tree-root.ts
+++ b/projects/limble-tree/src/lib/core/tree-root/tree-root.ts
@@ -160,7 +160,11 @@ export class TreeRoot<UserlandComponent>
       if (this.isDestroyed()) {
          throw new TreeError("Cannot grow a branch on a destroyed tree root");
       }
-      return new TreeBranch(this, { component, ...options });
+      try {
+         return new TreeBranch(this, { component, ...options });
+      } catch (error) {
+         this.handleUserlandError(error);
+      }
    }
 
    /** @returns `true` if the tree is destroyed, `false` otherwise */
@@ -216,5 +220,14 @@ export class TreeRoot<UserlandComponent>
    ): void {
       callback(this);
       this.treeNodeBase.traverse(callback);
+   }
+
+   private handleUserlandError(error: unknown): never {
+      // When an error occurs in a userland component during a tree operation,
+      // it can cause undefined, bizarre behavior in the tree. To prevent this,
+      // we destroy the tree and throw an error instead. This helps protect
+      // the end-user's data from corruption.
+      this.destroy();
+      this.treeNodeBase.handleUserlandError(error);
    }
 }

--- a/projects/limble-tree/src/lib/structure/tree-node.interface.ts
+++ b/projects/limble-tree/src/lib/structure/tree-node.interface.ts
@@ -8,6 +8,7 @@ import type { TreeEvent } from "./tree-event.interface";
 export interface TreeNode<Children, Component>
    extends Branchable<Children>,
       ComponentContainer<Component> {
+   destroy: () => void;
    dispatch: (event: TreeEvent) => void;
    events: () => Observable<TreeEvent>;
    isDestroyed: () => boolean;

--- a/projects/limble-tree/src/lib/test-util/branch-growth.component.ts
+++ b/projects/limble-tree/src/lib/test-util/branch-growth.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { TreeBranch } from "../core";
+import { EmptyComponent } from "./empty.component";
+
+@Component({
+   selector: "branch-growth",
+   template: "This is a test"
+})
+export class BranchGrowthComponent implements OnInit {
+   @Input() treeBranch?: TreeBranch<BranchGrowthComponent | EmptyComponent>;
+
+   public ngOnInit(): void {
+      if (this.treeBranch === undefined) {
+         throw new Error("treeBranch is undefined");
+      }
+      this.treeBranch.grow(EmptyComponent);
+      this.treeBranch.grow(EmptyComponent);
+   }
+}

--- a/projects/limble-tree/src/lib/test-util/error-constructor.component.ts
+++ b/projects/limble-tree/src/lib/test-util/error-constructor.component.ts
@@ -1,0 +1,11 @@
+import { Component } from "@angular/core";
+
+@Component({
+   selector: "error-constructor",
+   template: "This is a test"
+})
+export class ErrorConstructorComponent {
+   public constructor() {
+      throw new Error("This is a test error");
+   }
+}

--- a/projects/limble-tree/src/lib/test-util/error-init.component.ts
+++ b/projects/limble-tree/src/lib/test-util/error-init.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+   selector: "error-init",
+   template: "This is a test"
+})
+export class ErrorInitComponent implements OnInit {
+   public ngOnInit(): void {
+      throw new Error("This is a test error");
+   }
+}

--- a/projects/limble-tree/src/shared/has-property.ts
+++ b/projects/limble-tree/src/shared/has-property.ts
@@ -1,0 +1,6 @@
+export function hasProperty<T extends string>(
+   input: unknown,
+   prop: T
+): input is { [Key in T]: unknown } {
+   return typeof input === "object" && input !== null && prop in input;
+}


### PR DESCRIPTION
Closes #9.

Also addresses an error that would occur when a userland component tried to grow child branches in its own ngOnInit hook.