### PR TITLE
Fix multi-level defaultCollapsed

### DIFF
--- a/projects/limble-tree/package.json
+++ b/projects/limble-tree/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@limble/limble-tree",
-   "version": "1.0.0-beta.3",
+   "version": "1.0.0-beta.4",
    "peerDependencies": {
       "@angular/common": "^14.2.0",
       "@angular/core": "^14.2.0",

--- a/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
+++ b/projects/limble-tree/src/lib/core/tree-branch/tree-branch.ts
@@ -57,7 +57,6 @@ export class TreeBranch<UserlandComponent>
          parentBranchesContainer
       );
       const hostView = this.branchController.getHostView();
-      this.setIndentation(parent);
       if (
          parent instanceof TreeBranch &&
          parent.branchOptions.defaultCollapsed === true
@@ -74,8 +73,9 @@ export class TreeBranch<UserlandComponent>
                index: this._parent.branches().length
             })
          );
-         this.detectChanges();
+         this.setIndentation();
       }
+      this.detectChanges();
    }
 
    /** @returns All child branches as an array of TreeBranch instances, in order. */
@@ -506,11 +506,15 @@ export class TreeBranch<UserlandComponent>
       this.detachedView.reattach();
       container.insert(this.detachedView, index);
       this.detachedView = null;
+      this.setIndentation();
    }
 
-   private setIndentation(parent: TreeNode<UserlandComponent>): void {
-      const root = parent.root();
-      assert(root !== undefined);
+   private setIndentation(): void {
+      assert(this._parent !== undefined);
+      const root = this._parent.root();
+      if (root === undefined) {
+         return;
+      }
       const options = config.getConfig(root);
       const branchesContainerEl = this.branchController
          .getNativeElement()

--- a/projects/sandbox/src/app/app.component.ts
+++ b/projects/sandbox/src/app/app.component.ts
@@ -128,6 +128,10 @@ export class AppComponent implements AfterViewInit {
          .grow(DraggableComponent);
       branch3.grow(DraggableComponent);
       branch1b.grow(LoremIpsumComponent);
+      const branch1b1 = branch1b.grow(CollapsibleComponent, {
+         defaultCollapsed: true
+      });
+      branch1b1.grow(LoremIpsumComponent);
       const root2 = this.treeService.createEmptyTree<
          | LoremIpsumComponent
          | TextRendererComponent


### PR DESCRIPTION
The library would throw an error if defaultCollapsed was set on a parent and its child. This PR fixes that error.

Bumps to version 1.0.0-beta.4