### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/.github/workflows/pullRequestChecks.yml
+++ b/.github/workflows/pullRequestChecks.yml
@@ -1,5 +1,7 @@
 name: CodeChecks
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
    lint:
       runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [POC](https://github.com/orgs/LimbleCMMS/security/campaigns/1) security campaign:
- https://github.com/LimbleCMMS/limble-tree/security/code-scanning/3
To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only needs to read the repository contents (e.g., to check out the codebase), we will set `contents: read` as the minimal required permission.

  ---
  


- https://github.com/LimbleCMMS/limble-tree/security/code-scanning/2
To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow and will restrict the `GITHUB_TOKEN` permissions to `contents: read`, which is sufficient for the actions used in this workflow. This change ensures that the workflow adheres to the principle of least privilege.

  ---
  


- https://github.com/LimbleCMMS/limble-tree/security/code-scanning/1
To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs read-only operations, we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` used by the workflow has the least privileges necessary to complete the tasks.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
