### PR TITLE
ci: add explicit permissions and pin versions to SHA's

### DIFF
--- a/.github/workflows/pullRequestChecks.yml
+++ b/.github/workflows/pullRequestChecks.yml
@@ -1,13 +1,15 @@
 name: CodeChecks
 on: [pull_request]
+permissions:
+   contents: read
 jobs:
    lint:
       runs-on: ubuntu-22.04
       steps:
          - name: Get Codebase
-           uses: actions/checkout@v3
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
          - name: Install Node
-           uses: actions/setup-node@v3
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
            with:
               node-version: "22"
               cache: "npm"
@@ -20,9 +22,9 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
          - name: Get Codebase
-           uses: actions/checkout@v3
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
          - name: Install Node
-           uses: actions/setup-node@v3
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
            with:
               node-version: "22"
               cache: "npm"
@@ -35,9 +37,9 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
          - name: Get Codebase
-           uses: actions/checkout@v3
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
          - name: Install Node
-           uses: actions/setup-node@v3
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
            with:
               node-version: "22"
               cache: "npm"


### PR DESCRIPTION
## Context

The PR checks workflow had no explicit permissions block, meaning it ran with whatever the repo's default token scope was — likely broader than needed. Actions were also pinned to mutable v3 tags, which can be silently updated by the action authors (supply chain risk).

Note: no release required.

## Changes Made

- Added `permissions: contents: read` at the top level of `pullRequestChecks.yml` — all three jobs only need to read the repo, so everything else is now explicitly denied
- Bumped `actions/checkout` from v3 → v4.3.1, pinned to full SHA
- Bumped `actions/setup-node` from v3 → v4.4.0, pinned to full SHA
- Added inline `# vX.Y.Z` comments on each SHA ref for readability

## Testing Notes

- No functional changes — same lint, format, and test jobs run the same commands
- Workflow will behave identically; only the security posture changes
- Verify the new action SHAs resolve correctly on first run
